### PR TITLE
Fix for MigrationCommand::handle()

### DIFF
--- a/src/commands/MigrationCommand.php
+++ b/src/commands/MigrationCommand.php
@@ -37,7 +37,7 @@ class MigrationCommand extends Command {
      *
      * @return void
      */
-    public function fire()
+    public function handle()
     {
         $this->line('');
         $this->info('The migration process will create a migration file and a seeder for the countries list');


### PR DESCRIPTION
[ReflectionException]   Method Webpatser\Countries\MigrationCommand::handle() does not exist`

Fixes Issue #70 on parent repo.